### PR TITLE
Use dex initcontainer for gomplate config generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ Upstream documentation:
 
 ## Kubelogin installation
 
-Get the binary from
-[releases](https://github.com/int128/kubelogin/releases/tag/v1.28.0), and
-install as `kubectl-oidc_login` in `/usr/local/bin` or elsewhere in `$PATH`.
+We need Kubelogin and Kind installed. Run `make install-tools` to install them.
+
+## Makefile
+
+Check the Makefile for targets. Notably, `make run` will run the password grant
+setup, and `make run-pkce` will run the device-code setup.
 
 ## Cluster POC
 
@@ -65,18 +68,16 @@ For Dex, we also add LDAP connector configuration and set `passwordConnector` to
 `ldap`.
 
 You also need to input key and certificate from `gencert.sh` into
-`dex.example.com.tls` Secret for this test setup. These certs must be same as
+`dex.127.0.0.1.nip.io.tls` Secret for this test setup. These certs must be same as
 the generated CA certificate in previous step. Using expired or non-trusted
 certificates causes apiserver not trust Dex, and login attempts will fail even
 if the Dex token kubectl gained is valid.
 
-We also need to add a line to `/etc/hosts` to create fake Dex domain:
-`127.0.0.1       dex.example.com` or simply change all occurrences of
-`dex.example.com` with `127.0.0.1`. Here we use the `dex.example.com` in order
-to make a difference between Dex host and other services.
-
 Depending on the connector and grant type you want to configure, choose the
 appropriate configs below.
+
+We'll use built-in Gomplate to template the Dex config from mounted secrets to
+avoid exposing passwords in environment variables.
 
 #### Password connector
 

--- a/gencert.sh
+++ b/gencert.sh
@@ -1,26 +1,61 @@
 #!/bin/bash
+# generate test certificates for dex
 
-mkdir -p ssl
+set -e
 
-cat << EOF > ssl/req.cnf
+echo "Generating Dex test certificates..."
+
+WORKDIR=$(dirname "$0")
+SSLDIR="${WORKDIR}/ssl"
+
+# change this domain to match Dex issuer
+DEX_DOMAIN="dex.127.0.0.1.nip.io"
+
+mkdir -p "${SSLDIR}"
+cd "${SSLDIR}"
+
+# Generate CA private key
+openssl genrsa -out ca.key 2048
+
+# Generate CA certificate
+cat > req.cnf <<EOF
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+[req_distinguished_name]
+[v3_ca]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical,CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+EOF
+
+openssl req -new -x509 -days 365 -key ca.key -out ca.crt -subj "/CN=Dex Test CA" -config req.cnf
+
+# Generate Dex server private key
+openssl genrsa -out dex.key 2048
+
+# Generate Dex server certificate
+cat > dex.conf <<EOF
 [req]
 req_extensions = v3_req
 distinguished_name = req_distinguished_name
-
 [req_distinguished_name]
-
-[ v3_req ]
-basicConstraints = CA:FALSE
-keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+[v3_req]
 subjectAltName = @alt_names
-
 [alt_names]
-DNS.1 = dex.example.com
+DNS.1 = ${DEX_DOMAIN}
+DNS.2 = dex.dex
+DNS.3 = dex.dex.svc
+DNS.4 = dex.dex.svc.cluster.local
+DNS.5 = localhost
+IP.1 = 127.0.0.1
 EOF
 
-openssl genrsa -out ssl/ca-key.pem 2048
-openssl req -x509 -new -nodes -key ssl/ca-key.pem -days 10 -out ssl/ca.pem -subj "/CN=kube-ca"
+openssl req -new -key dex.key -out dex.csr -subj "/CN=${DEX_DOMAIN}" -config dex.conf
 
-openssl genrsa -out ssl/key.pem 2048
-openssl req -new -key ssl/key.pem -out ssl/csr.pem -subj "/CN=kube-ca" -config ssl/req.cnf
-openssl x509 -req -in ssl/csr.pem -CA ssl/ca.pem -CAkey ssl/ca-key.pem -CAcreateserial -out ssl/cert.pem -days 10 -extensions v3_req -extfile ssl/req.cnf
+# Sign the server certificate with CA
+openssl x509 -req -in dex.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out dex.crt -days 365 -extensions v3_req -extfile dex.conf
+
+# Clean up CSR
+rm -f dex.csr

--- a/k8s/dex-device-code.yaml
+++ b/k8s/dex-device-code.yaml
@@ -3,6 +3,16 @@ kind: Namespace
 metadata:
   name: dex
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex-ldap-credentials
+  namespace: dex
+type: Opaque
+stringData:
+  bindDN: "cn=admin,dc=example,dc=org"
+  bindPW: "adminpassword"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,18 +31,37 @@ spec:
         app: dex
     spec:
       serviceAccountName: dex
+      initContainers:
+      - name: config-generator
+        image: ghcr.io/dexidp/dex:v2.41.1
+        command:
+        - /bin/sh
+        - -c
+        - |
+          gomplate \
+            --file /etc/dex/templates/config.yaml.tmpl \
+            --datasource bindDN=file:///etc/dex/secrets/bindDN \
+            --datasource bindPW=file:///etc/dex/secrets/bindPW \
+            --out /etc/dex/config/config.yaml
+        volumeMounts:
+        - name: config-template
+          mountPath: /etc/dex/templates
+        - name: ldap-credentials
+          mountPath: /etc/dex/secrets
+        - name: generated-config
+          mountPath: /etc/dex/config
       containers:
       - image: ghcr.io/dexidp/dex:v2.41.1
         name: dex
-        command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
+        command: ["/usr/local/bin/dex", "serve", "/etc/dex/config/config.yaml"]
 
         ports:
         - name: https
           containerPort: 5556
 
         volumeMounts:
-        - name: config
-          mountPath: /etc/dex/cfg
+        - name: generated-config
+          mountPath: /etc/dex/config
         - name: tls
           mountPath: /etc/dex/tls
 
@@ -42,29 +71,31 @@ spec:
             port: 5556
             scheme: HTTPS
       volumes:
-      - name: config
+      - name: config-template
         configMap:
-          name: dex
-          items:
-          - key: config.yaml
-            path: config.yaml
+          name: dex-config-template
+      - name: ldap-credentials
+        secret:
+          secretName: dex-ldap-credentials
+      - name: generated-config
+        emptyDir: {}
       - name: tls
         secret:
-          secretName: dex.example.com.tls
+          secretName: dex.127.0.0.1.nip.io.tls
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: dex
+  name: dex-config-template
   namespace: dex
 data:
-  config.yaml: |
+  config.yaml.tmpl: |
     # issuer needs to match client's oidc-issuer-url
     # If its a https endpoint, you need to have the CA cert trusted both for
     # Dex and for the client, and also by Kubernetes Apiserver
     # NOTE: Read up on Dex issue if you're using any .local addresses here or
     # anywhere else in the config: https://github.com/dexidp/dex/issues/2469
-    issuer: https://dex.example.com:32000
+    issuer: https://dex.127.0.0.1.nip.io:32000
 
     storage:
       type: kubernetes
@@ -126,8 +157,8 @@ data:
         # environment variable which should be given as the value to `bindPW`.
         #
         # openLDAP testing admin creds, although read-only creds recommended
-        bindDN: cn=admin,dc=example,dc=org
-        bindPW: adminpassword
+        bindDN: {{ datasource "bindDN" }}
+        bindPW: {{ datasource "bindPW" }}
 
         # The attribute to display in the provided password prompt. If unset, will
         # display "Username"

--- a/k8s/dex-password.yaml
+++ b/k8s/dex-password.yaml
@@ -3,6 +3,16 @@ kind: Namespace
 metadata:
   name: dex
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex-ldap-credentials
+  namespace: dex
+type: Opaque
+stringData:
+  bindDN: "cn=admin,dc=example,dc=org"
+  bindPW: "adminpassword"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,18 +31,37 @@ spec:
         app: dex
     spec:
       serviceAccountName: dex
+      initContainers:
+      - name: config-generator
+        image: ghcr.io/dexidp/dex:v2.41.1
+        command:
+        - /bin/sh
+        - -c
+        - |
+          gomplate \
+            --file /etc/dex/templates/config.yaml.tmpl \
+            --datasource bindDN=file:///etc/dex/secrets/bindDN \
+            --datasource bindPW=file:///etc/dex/secrets/bindPW \
+            --out /etc/dex/config/config.yaml
+        volumeMounts:
+        - name: config-template
+          mountPath: /etc/dex/templates
+        - name: ldap-credentials
+          mountPath: /etc/dex/secrets
+        - name: generated-config
+          mountPath: /etc/dex/config
       containers:
       - image: ghcr.io/dexidp/dex:v2.41.1
         name: dex
-        command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
+        command: ["/usr/local/bin/dex", "serve", "/etc/dex/config/config.yaml"]
 
         ports:
         - name: https
           containerPort: 5556
 
         volumeMounts:
-        - name: config
-          mountPath: /etc/dex/cfg
+        - name: generated-config
+          mountPath: /etc/dex/config
         - name: tls
           mountPath: /etc/dex/tls
 
@@ -42,29 +71,31 @@ spec:
             port: 5556
             scheme: HTTPS
       volumes:
-      - name: config
+      - name: config-template
         configMap:
-          name: dex
-          items:
-          - key: config.yaml
-            path: config.yaml
+          name: dex-config-template
+      - name: ldap-credentials
+        secret:
+          secretName: dex-ldap-credentials
+      - name: generated-config
+        emptyDir: {}
       - name: tls
         secret:
-          secretName: dex.example.com.tls
+          secretName: dex.127.0.0.1.nip.io.tls
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: dex
+  name: dex-config-template
   namespace: dex
 data:
-  config.yaml: |
+  config.yaml.tmpl: |
     # issuer needs to match client's oidc-issuer-url
     # If its a https endpoint, you need to have the CA cert trusted both for
     # Dex and for the client, and also by Kubernetes Apiserver
     # NOTE: Read up on Dex issue if you're using any .local addresses here or
     # anywhere else in the config: https://github.com/dexidp/dex/issues/2469
-    issuer: https://dex.example.com:32000
+    issuer: https://dex.127.0.0.1.nip.io:32000
 
     storage:
       type: kubernetes
@@ -125,8 +156,8 @@ data:
         # environment variable which should be given as the value to `bindPW`.
         #
         # openLDAP testing admin creds, although read-only creds recommended
-        bindDN: cn=admin,dc=example,dc=org
-        bindPW: adminpassword
+        bindDN: {{ datasource "bindDN" }}
+        bindPW: {{ datasource "bindPW" }}
 
         # The attribute to display in the provided password prompt. If unset, will
         # display "Username"

--- a/k8s/openldap.yaml
+++ b/k8s/openldap.yaml
@@ -40,7 +40,6 @@ spec:
           value: dc=example,dc=org
         - name: LDAP_ADMIN_DN
           value: cn=admin,dc=example,dc=org
-status: {}
 ---
 apiVersion: v1
 kind: Service

--- a/kind.conf
+++ b/kind.conf
@@ -20,8 +20,8 @@ nodes:
     apiServer:
         extraArgs:
             v: "1"
-            oidc-issuer-url: https://dex.example.com:32000
+            oidc-issuer-url: https://dex.127.0.0.1.nip.io:32000
             oidc-client-id: kubelogin-test
-            oidc-ca-file: /etc/ssl/certs/dex-test/ca.pem
+            oidc-ca-file: /etc/ssl/certs/dex-test/ca.crt
             oidc-username-claim: email
             oidc-groups-claim: groups


### PR DESCRIPTION
Add also 'make install-tools' target to install kind and kubelogin.

Use nip.io addresses instead of example.com with /etc/hosts hack.